### PR TITLE
Update abseil to version 20211102.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+c_compiler_version:        # [linux and not aarch64]
+  - 8                      # [linux and not (s390x or aarch64 or ppc64le)]
+  - 8                      # [linux and ppc64le]
+  - 8                      # [linux and s390x]
+cxx_compiler_version:      # [linux]
+  - 8                      # [linux and not (s390x or aarch64 or ppc64le)]
+  - 8                      # [linux and ppc64le]
+  - 8                      # [linux and s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "abseil-cpp" %}
-{% set version = "20210324.2" %}
+{% set version = "20211102.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/abseil/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 59b862f50e710277f8ede96f083a5bb8d7c9595376146838b9580be90374ee1f
+  sha256: dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4
   patches:
     #- linux-librt.patch  # [linux]
     - clang4_osx_fix.diff  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage("abseil-cpp", max_pin="x.x") }}
+  missing_dso_whitelist:  # [s390x]
+    - '$RPATH/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,32 @@ requirements:
     - cmake
     - ninja
 
+# Testing section taken from Conda-Forge
+{% set absl_libs = [
+    "base", "civil_time", "cord", "cordz_functions", "cordz_handle", "cordz_info",
+    "cordz_sample_token", "examine_stack", "exponential_biased", "failure_signal_handler",
+    "flags", "flags_commandlineflag", "flags_config", "flags_marshalling", "flags_parse",
+    "flags_private_handle_accessor", "flags_program_name", "flags_reflection", "flags_usage",
+    "hash", "hashtablez_sampler", "int128", "log_severity", "low_level_hash", "periodic_sampler",
+    "random_distributions", "random_seed_gen_exception", "random_seed_sequences", "raw_hash_set",
+    "scoped_set_env", "spinlock_wait", "stacktrace", "status", "statusor", "strerror", "strings",
+    "symbolize", "synchronization", "time", "time_zone"
+] %}
 test:
   commands:
-    - test -f $PREFIX/lib/libabsl_base${SHLIB_EXT}  # [not win]
-    - if not exist %LIBRARY_LIB%\\absl_base.lib exit 1  # [win]
+    # windows (DLL + import library)
+    - if not exist %LIBRARY_BIN%\\abseil_dll.dll exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\abseil_dll.lib exit 1  # [win]
+
+    # absl_libs
+    {% for each_lib in absl_libs %}
+    # presence of shared libs
+    - test -f $PREFIX/lib/libabsl_{{ each_lib }}${SHLIB_EXT}      # [unix]
+    # absence of static libs
+    - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}.a              # [unix]
+    # TODO: do we want to get rid of the static windows libs?
+    # - if exist %LIBRARY_LIB%\\absl_{{ each_lib }}.lib exit 1      # [win]
+    {% endfor %}
 
 about:
   home: https://github.com/abseil/abseil-cpp


### PR DESCRIPTION
Recent versions of grpc-cpp don't build with the slightly older version of Abseil we currently use. Abseil pins itself to major.minor via run_exports (so basically the exact version). In that sense, it should be safe to upload this.

Release notes:
https://github.com/abseil/abseil-cpp/releases

Bug tracker:
https://github.com/abseil/abseil-cpp/issues