### PR TITLE
V20250814.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,13 @@
+# Disable overlinking errors, there are false positives now that GCC 15 has been released.
+#      - Needed DSO lib/libstdc++.so.6
+#      - Needed DSO lib/libgcc_s.so.1 
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--no-error-overlinking"
+
+staging_channel_upload_target: protobuf-6.33.0-build-4
+
+channels:
+  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-staging_channel_upload_target: protobuf-6.33.0-build-5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,13 +1,1 @@
-# Disable overlinking errors, there are false positives now that GCC 15 has been released.
-#      - Needed DSO lib/libstdc++.so.6
-#      - Needed DSO lib/libgcc_s.so.1 
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--no-error-overlinking"
-
-staging_channel_upload_target: protobuf-6.33.0-build-4
-
-channels:
-  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4
-
+staging_channel_upload_target: protobuf-6.33.0-build-5

--- a/recipe/build-abseil.sh
+++ b/recipe/build-abseil.sh
@@ -5,11 +5,6 @@ set -exuo pipefail
 mkdir -p build
 cd build
 
-if [[ "${target_platform}" == osx-* ]]; then
-    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
-    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-fi
-
 if [[ "$PKG_NAME" == "libabseil-tests" ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_TESTING=ON -DABSL_BUILD_TESTING=ON"
     CMAKE_ARGS="${CMAKE_ARGS} -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,8 @@ c_compiler:     # [win]
   - vs2022      # [win]
 cxx_compiler:   # [win]
   - vs2022      # [win]
+
+c_compiler_version:    # [linux]
+  - 14                 # [linux]
+cxx_compiler_version:  # [linux]
+  - 14                 # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,13 +1,6 @@
-cxx_compiler:               # [win]
-  - 'vs2019'                # [win]
-c_compiler:                 # [win]
-  - 'vs2019'                # [win]
-
-# abseil now only support MacOS >=10.15, see
-# https://github.com/abseil/abseil-cpp#support
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-  - "10.15"                # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - "10.15"                # [osx and x86_64]
-CONDA_BUILD_SYSROOT:       # [osx and x86_64]
-  - /opt/MacOSX10.15.sdk   # [osx and x86_64]
+# google has moved the lower bound for MSVC to v2022 already in April 2024, see
+# https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
+c_compiler:     # [win]
+  - vs2022      # [win]
+cxx_compiler:   # [win]
+  - vs2022      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20250127.0" %}
+{% set version = "20250814.1" %}
 {% set v_major = version.split(".")[0] %}
 # needs to match across all dependent packages; using C++20
 # is potentially problematic in some cases, see #45
@@ -7,17 +7,18 @@
 # shared builds for flags_* libraries are not supported on windows, see
 # https://github.com/abseil/abseil-cpp/pull/1115
 {% set absl_libs_always_static_on_win = [
-    "log_flags", "flags_commandlineflag", "flags_config", "flags_marshalling", "flags_parse",
-    "flags_private_handle_accessor", "flags_program_name", "flags_reflection", "flags_usage"
+    "decode_rust_punycode", "demangle_rust", "flags_commandlineflag", "flags_config", "flags_marshalling",
+    "flags_parse", "flags_private_handle_accessor", "flags_program_name", "flags_reflection", "flags_usage",
+    "hashtable_profiler", "log_flags", "poison", "profile_builder"
 ] %}
 
 {% set absl_libs = absl_libs_always_static_on_win + [
-    "base", "civil_time", "cord", "cordz_functions", "cordz_handle", "cordz_info",
-    "cordz_sample_token", "examine_stack", "exponential_biased", "failure_signal_handler",
-    "hash", "hashtablez_sampler", "int128", "log_severity", "low_level_hash", "periodic_sampler",
+    "base", "civil_time", "crc_cord_state", "crc_cpu_detect", "crc32c", "cord", "cordz_functions",
+    "cordz_handle", "cordz_info", "cordz_sample_token", "die_if_null", "examine_stack", "exponential_biased",
+    "failure_signal_handler", "hash", "hashtablez_sampler", "int128", "log_severity", "periodic_sampler",
     "random_distributions", "random_seed_gen_exception", "random_seed_sequences", "raw_hash_set",
     "scoped_set_env", "spinlock_wait", "stacktrace", "status", "statusor", "strerror", "strings",
-    "symbolize", "synchronization", "time", "time_zone"
+    "symbolize", "synchronization", "throw_delegate", "time", "time_zone"
 ] %}
 # test helper targets (but used e.g. by protobuf)
 {% set absl_test_libs = ["scoped_mock_log"] %}
@@ -28,23 +29,19 @@ package:
 
 source:
   url: https://github.com/abseil/abseil-cpp/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 16242f394245627e508ec6bb296b433c90f8d914f73b9c026fddb905e27276e8
+  sha256: 1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1
   patches:
     # Helps downstream packages import the dll without an extra define
     # https://github.com/conda-forge/abseil-cpp-feedstock/issues/43#issuecomment-1242969515
     - patches/0001-default-dll-import-for-windows.patch
     # avoid that compilation in C++20 mode changes the ABI vs. C++17
     - patches/0002-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
-    # workaround for https://github.com/abseil/abseil-cpp/issues/1624
-    - patches/0003-unconditionally-export-Mutex-Destructor.patch  # [linux]
+    # Avoid SHELL:-Xarch… flags leaking into pkg-config files
+    # These flagse are not used anyways in our setup
+    - patches/0003-Don-t-try-to-compile-to-multiple-OSX-arches.patch
 
 build:
   number: 0
-
-requirements:
-  build:
-    - patch    # [unix]
-    - m2-patch # [win]
 
 outputs:
   # default behaviour is shared; however note that upstream does not support
@@ -55,31 +52,26 @@ outputs:
     build:
       string: cxx{{ cxx_standard }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       run_exports:
-        # breaking changes listed on patch versions
-        - {{ pin_subpackage("libabseil", max_pin="x.x") }}
+        - {{ pin_subpackage("libabseil", max_pin="x") }}
         # also pin on ABI variant
         - libabseil =*=cxx{{ cxx_standard }}*
-        # abseil needs the 10.13 headers even just to be `# include`d;
-        # ensure that all dependent packages reflect that to
-        # avoid the solver getting stuck in no-man's-land.
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
-      missing_dso_whitelist:  # [s390x]
-        - '$RPATH/ld64.so.1'  # [s390x]
+
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja-base
       run_constrained:
         - libabseil-static ={{ version }}=cxx{{ cxx_standard }}*
-        # make sure we don't co-install with old version of old package name 
+        # make sure we don't co-install with old version of old package name
         - abseil-cpp ={{ version }}
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
     test:
       requires:
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja-base
         - pkg-config
@@ -149,10 +141,11 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja-base
       host:
-        - gtest 1.14
+        - gtest {{ gtest }}
         - {{ pin_subpackage("libabseil", exact=True) }}
       run:
         - gtest
@@ -161,6 +154,7 @@ outputs:
     test:
       requires:
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - cmake
         - ninja-base
         - pkg-config

--- a/recipe/patches/0001-default-dll-import-for-windows.patch
+++ b/recipe/patches/0001-default-dll-import-for-windows.patch
@@ -1,17 +1,17 @@
-From e8044cc76e21b88ef92d36c62e56b8015b75f588 Mon Sep 17 00:00:00 2001
+From 27f96d26d74908c3a838bd9359175a6c3ff176ce Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 11 Sep 2022 10:32:19 -0400
-Subject: [PATCH 1/2] default dll import for windows
+Subject: [PATCH 1/3] default dll import for windows
 
 ---
  absl/base/config.h | 5 ++---
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/absl/base/config.h b/absl/base/config.h
-index 0b22167e..56acb3ba 100644
+index a31b9a5d..b2cf7a78 100644
 --- a/absl/base/config.h
 +++ b/absl/base/config.h
-@@ -705,10 +705,9 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+@@ -619,10 +619,9 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
  #if defined(_MSC_VER)
  #if defined(ABSL_BUILD_DLL)
  #define ABSL_DLL __declspec(dllexport)

--- a/recipe/patches/0002-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
+++ b/recipe/patches/0002-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
@@ -1,7 +1,7 @@
-From 1140318d3504be7e4b8c1dbc03eeb7d19da988d5 Mon Sep 17 00:00:00 2001
+From e7640aa9130977071ec525e6dfc764b54cb52cb5 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 7 Feb 2024 17:07:42 +0100
-Subject: [PATCH 2/2] don't use C++20 stdlib-features which change ABI compared
+Subject: [PATCH 2/3] don't use C++20 stdlib-features which change ABI compared
  to C++17 baseline
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 2/2] don't use C++20 stdlib-features which change ABI compared
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7c82b3a7..1d4f421f 100644
+index 1e7c8563..fb0a9c56 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -221,7 +221,7 @@ if(ABSL_ENABLE_INSTALL)
+@@ -220,7 +220,7 @@ if(ABSL_ENABLE_INSTALL)
      foreach(FEATURE "ORDERING")
        string(REPLACE
        "#define ABSL_OPTION_USE_STD_${FEATURE} 2"

--- a/recipe/patches/0003-Don-t-try-to-compile-to-multiple-OSX-arches.patch
+++ b/recipe/patches/0003-Don-t-try-to-compile-to-multiple-OSX-arches.patch
@@ -1,0 +1,34 @@
+From acfe42c2a634212e5903e6aa96aea0697a42891f Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <uwe.korn@quantco.com>
+Date: Wed, 25 Sep 2024 20:56:25 +0200
+Subject: [PATCH 3/3] Don't try to compile to multiple OSX arches
+
+---
+ absl/copts/AbseilConfigureCopts.cmake | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/absl/copts/AbseilConfigureCopts.cmake b/absl/copts/AbseilConfigureCopts.cmake
+index f1d8b266..64ed9f3c 100644
+--- a/absl/copts/AbseilConfigureCopts.cmake
++++ b/absl/copts/AbseilConfigureCopts.cmake
+@@ -38,13 +38,13 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
+   # In both cases, the viable strategy is to pass all arguments at once, allowing
+   # the compiler to dispatch arch-specific arguments to a designated backend.
+   set(ABSL_RANDOM_RANDEN_COPTS "")
+-  foreach(_arch IN ITEMS "x86_64" "arm64")
+-    string(TOUPPER "${_arch}" _arch_uppercase)
+-    string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
+-    foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
+-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
+-    endforeach()
+-  endforeach()
++  #foreach(_arch IN ITEMS "x86_64" "arm64")
++  #  string(TOUPPER "${_arch}" _arch_uppercase)
++  #  string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
++  #  foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
++  #    list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
++  #  endforeach()
++  #endforeach()
+   # If a compiler happens to deal with an argument for a currently unused
+   # architecture, it will warn about an unused command line argument.
+   option(ABSL_RANDOM_RANDEN_COPTS_WARNING OFF


### PR DESCRIPTION
abseil 20250814.1

**Destination channel:**  defaults

### Links

- [PKG-10679](https://anaconda.atlassian.net/browse/PKG-10679) 
- [Upstream repository](https://github.com/abseil/abseil-cpp/tree/20250814.1)
- [artifacts](https://staging.continuum.io/pbp/protobuf-6.33.0-build-4)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/re2-feedstock/pull/6
  - https://github.com/AnacondaRecipes/protobuf-feedstock/pull/28
  - https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/32
  - https://github.com/AnacondaRecipes/grpc-cpp-feedstock/pull/37
  - https://github.com/AnacondaRecipes/grpcio-status-feedstock/pull/4

### Explanation of changes:

- Rebase patches, updating from conda forge.
- Removes `LIBCPP_DISABLE_AVAILABILITY`, as with other feedstocks, that is now causing errors. 
- Bump Windows to vs2022 to match upstream reqs
- Use GCC 14 on linux


[PKG-10679]: https://anaconda.atlassian.net/browse/PKG-10679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ