### PR TITLE
PKG-15914: update abseil-cpp to 20260526.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,27 +1,8 @@
-{% set version = "20260107.0" %}
+{% set version = "20260526.0" %}
 {% set v_major = version.split(".")[0] %}
 # needs to match across all dependent packages; using C++20
 # is potentially problematic in some cases, see #45
 {% set cxx_standard = 17 %}
-
-# shared builds for flags_* libraries are not supported on windows, see
-# https://github.com/abseil/abseil-cpp/pull/1115
-{% set absl_libs_always_static_on_win = [
-    "decode_rust_punycode", "demangle_rust", "flags_commandlineflag", "flags_config", "flags_marshalling",
-    "flags_parse", "flags_private_handle_accessor", "flags_program_name", "flags_reflection", "flags_usage",
-    "hashtable_profiler", "log_flags", "poison", "profile_builder"
-] %}
-
-{% set absl_libs = absl_libs_always_static_on_win + [
-    "base", "civil_time", "crc_cord_state", "crc_cpu_detect", "crc32c", "cord", "cordz_functions",
-    "cordz_handle", "cordz_info", "cordz_sample_token", "die_if_null", "examine_stack", "exponential_biased",
-    "failure_signal_handler", "hash", "hashtablez_sampler", "int128", "log_severity", "periodic_sampler",
-    "random_distributions", "random_seed_gen_exception", "random_seed_sequences", "raw_hash_set",
-    "scoped_set_env", "spinlock_wait", "stacktrace", "status", "statusor", "strerror", "strings",
-    "symbolize", "synchronization", "throw_delegate", "time", "time_zone"
-] %}
-# test helper targets (but used e.g. by protobuf)
-{% set absl_test_libs = ["scoped_mock_log"] %}
 
 package:
   name: abseil-split
@@ -29,7 +10,7 @@ package:
 
 source:
   url: https://github.com/abseil/abseil-cpp/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 4c124408da902be896a2f368042729655709db5e3004ec99f57e3e14439bc1b2
+  sha256: 6e1aee535473414164bf83e4ebc40240dec71a4701f8a642d906e95bea1aea0c
   patches:
     # Helps downstream packages import the dll without an extra define
     # https://github.com/conda-forge/abseil-cpp-feedstock/issues/43#issuecomment-1242969515
@@ -45,7 +26,8 @@ build:
 
 outputs:
   # default behaviour is shared; however note that upstream does not support
-  # fully shared builds on windows, and some static libs will remain, see above
+  # fully shared builds on windows, and some static libs will remain
+  # (see ALWAYS_STATIC list in test-abseil-libs.{sh,bat})
   - name: libabseil
     script: build-abseil.sh  # [unix]
     script: build-abseil.bat  # [win]
@@ -77,6 +59,8 @@ outputs:
         - pkg-config
       files:
         - cmake_test/
+        - test-abseil-libs.sh   # [unix]
+        - test-abseil-libs.bat  # [win]
       commands:
         # windows-only (almost-)all-in-one DLL + import library
         - if not exist %LIBRARY_BIN%\\abseil_dll.dll exit 1           # [win]
@@ -85,31 +69,9 @@ outputs:
         - if exist %LIBRARY_BIN%\\abseil_test_dll.dll exit 1          # [win]
         - if exist %LIBRARY_LIB%\\abseil_test_dll.lib exit 1          # [win]
 
-        # absl_* libraries
-      {% for each_lib in absl_libs %}
-        # presence of shared libs
-        - test -f $PREFIX/lib/libabsl_{{ each_lib }}${SHLIB_EXT}      # [unix]
-        # absence of static libs
-        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}.a              # [unix]
-
-        # some static libs remain on windows even for shared builds, see above
-        {% if each_lib in absl_libs_always_static_on_win %}
-        - if not exist %LIBRARY_LIB%\\absl_{{ each_lib }}.lib exit 1  # [win]
-        {% else %}
-        - if exist %LIBRARY_LIB%\\absl_{{ each_lib }}.lib exit 1      # [win]
-        {% endif %}
-
-        # pkg-config (should point to abseil_dll on shared windows builds)
-        - pkg-config --print-errors --exact-version "{{ v_major }}" absl_{{ each_lib }}
-      {% endfor %}
-
-        # absence of test targets in regular abseil output
-      {% for each_lib in absl_test_libs %}
-        # absence of all libs
-        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}${SHLIB_EXT}    # [unix]
-        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}.a              # [unix]
-        - if exist %LIBRARY_LIB%\\absl_{{ each_lib }}.lib exit 1      # [win]
-      {% endfor %}
+        # absl_* libraries (looped checks live in test-abseil-libs scripts)
+        - bash ./test-abseil-libs.sh libabseil                        # [unix]
+        - call test-abseil-libs.bat libabseil                         # [win]
 
         # pkg-config (abseil_dll)
         - pkg-config --print-errors --exact-version "{{ v_major }}" abseil_dll  # [win]
@@ -160,21 +122,16 @@ outputs:
         - pkg-config
       files:
         - cmake_test/
+        - test-abseil-libs.sh   # [unix]
+        - test-abseil-libs.bat  # [win]
       commands:
         # windows-only (almost-)all-in-one DLL + import library
         - if not exist %LIBRARY_BIN%\\abseil_test_dll.dll exit 1      # [win]
         - if not exist %LIBRARY_LIB%\\abseil_test_dll.lib exit 1      # [win]
 
-        # absl_* libraries
-      {% for each_lib in absl_test_libs %}
-        # presence of shared libs
-        - test -f $PREFIX/lib/libabsl_{{ each_lib }}${SHLIB_EXT}      # [unix]
-        # absence of static libs
-        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}.a              # [unix]
-
-        # pkg-config (should point to abseil_test_dll on shared windows builds)
-        - pkg-config --print-errors --exact-version "{{ v_major }}" absl_{{ each_lib }}
-      {% endfor %}
+        # absl_* test helper libraries (looped checks in test-abseil-libs scripts)
+        - bash ./test-abseil-libs.sh libabseil-tests                   # [unix]
+        - call test-abseil-libs.bat libabseil-tests                    # [win]
 
         # pkg-config abseil_test_dll
         - pkg-config --print-errors --exact-version "{{ v_major }}" abseil_test_dll  # [win]

--- a/recipe/test-abseil-libs.bat
+++ b/recipe/test-abseil-libs.bat
@@ -1,0 +1,51 @@
+@echo on
+REM Library presence / pkg-config checks for libabseil and libabseil-tests.
+REM Kept as a script (not a Jinja for-loop) so conda-lint can parse meta.yaml.
+
+SetLocal EnableDelayedExpansion
+
+if "%~1"=="" (
+    echo usage: test-abseil-libs.bat ^<libabseil^|libabseil-tests^>
+    exit /b 1
+)
+set "MODE=%~1"
+
+for /f "tokens=1 delims=." %%a in ("%PKG_VERSION%") do set "V_MAJOR=%%a"
+
+REM shared builds for flags_* libraries are not supported on windows, see
+REM https://github.com/abseil/abseil-cpp/pull/1115
+set "ALWAYS_STATIC=decode_rust_punycode demangle_rust flags_commandlineflag flags_config flags_marshalling flags_parse flags_private_handle_accessor flags_program_name flags_reflection flags_usage hashtable_profiler log_flags poison profile_builder"
+
+set "ABSL_LIBS=%ALWAYS_STATIC% base civil_time crc_cord_state crc_cpu_detect crc32c cord cordz_functions cordz_handle cordz_info cordz_sample_token die_if_null examine_stack exponential_biased failure_signal_handler hash hashtablez_sampler int128 log_severity periodic_sampler random_distributions random_seed_gen_exception random_seed_sequences raw_hash_set scoped_set_env spinlock_wait stacktrace status statusor strerror strings symbolize synchronization throw_delegate time time_zone"
+
+set "ABSL_TEST_LIBS=scoped_mock_log"
+
+if "%MODE%"=="libabseil" (
+    for %%L in (%ABSL_LIBS%) do (
+        set "IS_STATIC=0"
+        for %%S in (%ALWAYS_STATIC%) do (
+            if /I "%%L"=="%%S" set "IS_STATIC=1"
+        )
+        if "!IS_STATIC!"=="1" (
+            if not exist "%LIBRARY_LIB%\absl_%%L.lib" exit 1
+        ) else (
+            if exist "%LIBRARY_LIB%\absl_%%L.lib" exit 1
+        )
+        pkg-config --print-errors --exact-version "!V_MAJOR!" absl_%%L
+        if errorlevel 1 exit 1
+    )
+
+    for %%L in (%ABSL_TEST_LIBS%) do (
+        if exist "%LIBRARY_LIB%\absl_%%L.lib" exit 1
+    )
+) else if "%MODE%"=="libabseil-tests" (
+    for %%L in (%ABSL_TEST_LIBS%) do (
+        pkg-config --print-errors --exact-version "!V_MAJOR!" absl_%%L
+        if errorlevel 1 exit 1
+    )
+) else (
+    echo unknown mode: %MODE%
+    exit /b 1
+)
+
+exit /b 0

--- a/recipe/test-abseil-libs.sh
+++ b/recipe/test-abseil-libs.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Library presence / pkg-config checks for libabseil and libabseil-tests.
+# Kept as a script (not a Jinja for-loop) so conda-lint can parse meta.yaml.
+
+set -exuo pipefail
+
+mode="${1:?usage: test-abseil-libs.sh <libabseil|libabseil-tests>}"
+v_major="${PKG_VERSION%%.*}"
+
+# shared builds for flags_* libraries are not supported on windows, see
+# https://github.com/abseil/abseil-cpp/pull/1115
+# (list kept here for parity with the Windows test script)
+absl_libs_always_static_on_win=(
+    decode_rust_punycode demangle_rust flags_commandlineflag flags_config flags_marshalling
+    flags_parse flags_private_handle_accessor flags_program_name flags_reflection flags_usage
+    hashtable_profiler log_flags poison profile_builder
+)
+
+absl_libs=(
+    "${absl_libs_always_static_on_win[@]}"
+    base civil_time crc_cord_state crc_cpu_detect crc32c cord cordz_functions
+    cordz_handle cordz_info cordz_sample_token die_if_null examine_stack exponential_biased
+    failure_signal_handler hash hashtablez_sampler int128 log_severity periodic_sampler
+    random_distributions random_seed_gen_exception random_seed_sequences raw_hash_set
+    scoped_set_env spinlock_wait stacktrace status statusor strerror strings
+    symbolize synchronization throw_delegate time time_zone
+)
+
+# test helper targets (but used e.g. by protobuf)
+absl_test_libs=(scoped_mock_log)
+
+if [[ "${mode}" == "libabseil" ]]; then
+    for each_lib in "${absl_libs[@]}"; do
+        test -f "${PREFIX}/lib/libabsl_${each_lib}${SHLIB_EXT}"
+        test ! -f "${PREFIX}/lib/libabsl_${each_lib}.a"
+        pkg-config --print-errors --exact-version "${v_major}" "absl_${each_lib}"
+    done
+
+    for each_lib in "${absl_test_libs[@]}"; do
+        test ! -f "${PREFIX}/lib/libabsl_${each_lib}${SHLIB_EXT}"
+        test ! -f "${PREFIX}/lib/libabsl_${each_lib}.a"
+    done
+elif [[ "${mode}" == "libabseil-tests" ]]; then
+    for each_lib in "${absl_test_libs[@]}"; do
+        test -f "${PREFIX}/lib/libabsl_${each_lib}${SHLIB_EXT}"
+        test ! -f "${PREFIX}/lib/libabsl_${each_lib}.a"
+        pkg-config --print-errors --exact-version "${v_major}" "absl_${each_lib}"
+    done
+else
+    echo "unknown mode: ${mode}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Version
- `abseil-cpp` `20260526.0`

## Destination channel
- `main`

## Links
- Jira: [PKG-15914](https://anaconda.atlassian.net/browse/PKG-15914)
- PyPI: N/A
- GitHub: [abseil/abseil-cpp](https://github.com/abseil/abseil-cpp/releases/tag/20260526.0)

## Explanation of changes
- Bumps `abseil-cpp` from `20260107.0` to `20260526.0` and updates the source checksum.
- Moves the repeated package test library checks into shipped `test-abseil-libs` scripts so the `libabseil` and `libabseil-tests` output tests run correctly from the packaged recipe snapshot.
- Keeps the existing CMake smoke test in place


[PKG-15914]: https://anaconda.atlassian.net/browse/PKG-15914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ